### PR TITLE
Uniformly indent log in text output for readability

### DIFF
--- a/pkg/apis/scorecard/v1alpha2/formatter.go
+++ b/pkg/apis/scorecard/v1alpha2/formatter.go
@@ -15,6 +15,7 @@
 package v1alpha2
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -82,7 +83,10 @@ func (s ScorecardOutput) MarshalText() (string, error) {
 
 		if result.Log != "" {
 			sb.WriteString(fmt.Sprintf("\tLog:\n"))
-			sb.WriteString(fmt.Sprintf("\t\t%s\n", result.Log))
+			scanner := bufio.NewScanner(strings.NewReader(result.Log))
+			for scanner.Scan() {
+				sb.WriteString(fmt.Sprintf("\t\t%s\n", scanner.Text()))
+			}
 		}
 
 		sb.WriteString(fmt.Sprintf("\n"))


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Indents all lines of the log, instead of the first line

**Motivation for the change:**
the result output was difficult to follow with long logs
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
